### PR TITLE
Change publish_test.yaml to not run on `main`

### DIFF
--- a/.github/workflows/publish_test.yaml
+++ b/.github/workflows/publish_test.yaml
@@ -2,7 +2,6 @@ name: Test Publish TestPyPI Packages
 on:
   push:
     branches:
-      - main
       - "v*"
   pull_request:
 

--- a/.github/workflows/publish_test.yaml
+++ b/.github/workflows/publish_test.yaml
@@ -1,8 +1,5 @@
 name: Test Publish TestPyPI Packages
 on:
-  push:
-    branches:
-      - "v*"
   pull_request:
 
 permissions:

--- a/envoy/version.py
+++ b/envoy/version.py
@@ -9,7 +9,7 @@ __version_info__ = {
     "micro": 0,
     "releaselevel": "rc",
     "post": 0,
-    "serial": 1,
+    "serial": 2,
 }
 
 


### PR DESCRIPTION
### Scope of changes

Change publish_test.yaml to not run on `main` because it will usually always fail since the version doesn't change from the PR upload that it was merged from, and this is only helpful for in a PR context anways. The test-pypi distribution will only happen on PRs.

### Type of change

- [x] bug fix
- [ ] new feature
- [ ] documentation
- [x] other (describe)

### Acceptance criteria

No special needs.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.


